### PR TITLE
chore(deps): renovate to keep mix.exs deps version requirements wide by default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "rangeStrategy": "widen"
 }


### PR DESCRIPTION
I think this strategy is better suited for an elixir package, in contrast to end user applications.

For packages, like this one, we rather have it widen the version requirement in the PR and we asses whether we keep it wide or we shrink it (i.e. drop support for older version of the dependency). But good to have it default to not drop support when opening PR like in https://github.com/mimiquate/tower_honeybadger/pull/71#pullrequestreview-3943784574.

https://docs.renovatebot.com/configuration-options/#rangestrategy